### PR TITLE
Add RouteMap, an alternative URL registration API

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,3 +56,45 @@ Function based views:
 
 If you don't specify url name for functional views it will be derived from
 function name.
+
+
+
+Using the RouteMap
+----------------
+
+An alternative to ``URLView`` and ``@url_view`` is the RouteMap.
+
+The RouteMap is an object that maps URLs to routes. Usually, one is created
+in every view module, and named "route". With class and callable views,
+it's used as a decorator::
+
+    from urljects import RouteMap
+    route = RouteMap()
+
+    @route(U / 'post')
+    def post_view():
+        return render()
+
+    @route(U / 'detail', name='detail_view')
+    class DetailView(View):
+        pass
+
+It can also be used as a function, typically for view names as strings::
+
+    route(U / 'profile', 'users_app.views.profile_view')
+
+In urls.py, use the RouteMap's ``include`` method::
+
+    from my_app.blog.views import route as blog_routemap
+    urlpatterns = [
+        blog_routemap.include(U / 'blog')
+    ]
+
+The ``@route`` decorator may be used multiple times on a single view.
+The URLs it records are included in the order the views are defined in,
+or they can be given a priority::
+
+    @route(U / slug, priority=-1)
+    def post_view():
+        """ A catch-all view with low priority """
+        return render()

--- a/tests/included_app/routed_views.py
+++ b/tests/included_app/routed_views.py
@@ -1,0 +1,21 @@
+from django.views.generic.base import View
+
+from urljects import RouteMap, U
+
+route = RouteMap()
+
+
+@route(U / 'RoutedView', name='RoutedView')
+class RoutedView(View):
+    pass
+
+
+@route(U / 'routed_view')
+@route(U / 'aliased_view', name='aliased_view')
+def routed_view():
+    pass
+
+route(U / 'string_view', 'tests.included_app.routed_views.string_view')
+
+def string_view():
+    pass

--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -153,3 +153,16 @@ class TestAPP(unittest.TestCase):
 
         self.assertEqual(reverse(viewname='wild_card:IncludedView'),
                          u'/IncludedView')
+
+    def test_named_routed_views(self):
+        self.assertEqual(reverse(viewname='routed:RoutedView'),
+                         u'/routed/RoutedView')
+
+        self.assertEqual(reverse(viewname='routed:routed_view'),
+                         u'/routed/routed_view')
+
+        self.assertEqual(reverse(viewname='routed:aliased_view'),
+                         u'/routed/aliased_view')
+
+        self.assertEqual(reverse(viewname='routed:string_view'),
+                         u'/routed/string_view')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,6 @@
 from . import views
 from .included_app import views as included_views
+from .included_app.routed_views import route as routed_views
 from urljects import U, url, view_include
 
 
@@ -11,4 +12,5 @@ urlpatterns = [
     url(U / 'string', view_include('tests.included_app.views',
                                    namespace='string_import')),
     url(U, view_include(included_views, namespace='wild_card')),
+    routed_views.include(U / 'routed', namespace='routed'),
 ]

--- a/urljects/__init__.py
+++ b/urljects/__init__.py
@@ -1,4 +1,5 @@
 __version__ = '1.0.4'
 
 from .urljects import url, URLView, url_view, view_include
+from .routemap import RouteMap
 from .patterns import *

--- a/urljects/routemap.py
+++ b/urljects/routemap.py
@@ -1,0 +1,65 @@
+import operator
+
+from django.conf import urls
+
+from .urljects import url, resolve_name
+
+
+class RouteMap(object):
+    """
+        Records mapping of URLs to views
+    """
+
+    def __init__(self):
+        self.routes = []
+        self.default_prefix = ''
+
+    def __call__(self, url_pattern, view=None, name=None, priority=0,
+                 prefix=None, kwargs=None):
+        """
+        Register a URL -> view mapping, or return a registering decorator
+
+        :param url_pattern: regex or URLPattern or anything passable to url()
+        :param view: The view. If None, a decorator will be returned
+
+        The remaining arguments should be givn by name:
+
+        :param name: name of the view; resolve_name() will be used otherwise.
+        :param priority: priority for sorting; pass e.g. -1 for catch-all routes
+        :param prefix: passed to url()
+        :param kwargs: passed to url()
+        """
+        if prefix is None:
+            prefix = self.default_prefix
+
+        def router_decorator(view):
+            if name is None:
+                resolved_name = resolve_name(view)
+            else:
+                resolved_name = name
+            url_object = url(url_pattern, view, kwargs=kwargs,
+                             name=resolved_name, prefix=prefix)
+            self.routes.append((priority, url_object))
+            return view
+
+        # If view was given, decorate it immediately
+        if view is not None:
+            return router_decorator(view)
+
+        return router_decorator
+
+    def include(self, location, namespace=None, app_name=None):
+        """
+        Return an object suitable for url_patterns.
+
+        :param location: root URL for all URLs from this router
+        :param namespace: passed to url()
+        :param app_name: passed to url()
+        """
+        sorted_entries = sorted(self.routes, key=operator.itemgetter(0),
+                                reverse=True)
+        arg = [u for p, u in sorted_entries]
+        return url(location, urls.include(
+            arg=arg,
+            namespace=namespace,
+            app_name=app_name))


### PR DESCRIPTION
This is an idea about a more explicit API for view registration. It does not use getmembers() or guessing based on isfunction()/isclass().

I'm not all that familiar with Django, so I probably missed some details. Take this as an idea.