### PR TITLE
Parallel port to django 1.9+ and added `separator` stripping from URL bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@
 [![Requirements Status](https://requires.io/github/Visgean/urljects/requirements.svg?branch=master)](https://requires.io/github/Visgean/urljects/requirements/?branch=master)
 [![Coverage Status](https://coveralls.io/repos/Visgean/urljects/badge.svg?branch=master&service=github)](https://coveralls.io/github/Visgean/urljects?branch=master)
 
+Library which greatly simplifies django urls definition! And as a side effect it makes translated urls amazingly easy. Just compare
+
+```python
+# old urls notation
+url('^detail/(?<slug>[\w-]+)', MyDetailView.as_view(), name='detail')
+# easified !even translated! notation
+url(U / _('detail') / slug, MyDetailView, name='detail')
+```
 
 ## Getting rid of ``urls.py``
 
@@ -27,17 +35,23 @@ your app's views directly in root ``urls.py``.
 
 #### Soo how to put urls directly into views?
 
-I am glad you asked! For class based views simply inherit from ``URLView``.
+I am glad you asked! For class based views simply inherit from ``URLView`` and add
+``name`` and ``url`` as their attributes.
 
 ```python
+from urljects import URLView, U, slug
+from django.views.generic import DetailView
+
 class ItemDetail(URLView, DetailView):
     name = 'detail'
     url = U / 'detail' / slug
 ```
 
-a lot of people enjoy functional views, for those there is ``url_view`` decorator.
+A lot of people enjoy functional views, for those there is ``url_view`` decorator.
 
 ```python
+from urljects import url_view
+
 @url_view(U / 'category' / rest)
 def detail(request, rest)
     ...
@@ -48,7 +62,6 @@ then old-style ``include`` them afterwards.
 
 
 ## I want to keep my urls.py
-
 
 Quite often you need some ``urls.py`` - for example your root urls. Then you can
 use patterns like ``slug`` or ``rest`` as shown above inside your ``urls.py``.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Django URL Objects = URLjects
-=============================
+# Django URL Objects = URLjects
+
 
 [![Travis CL](https://img.shields.io/travis/Visgean/urljects.svg)](https://travis-ci.org/Visgean/urljects)
 [![Documentation Status](https://readthedocs.org/projects/urljects/badge/?version=latest)](https://urljects.readthedocs.org/en/latest/)
@@ -9,13 +9,13 @@ Django URL Objects = URLjects
 [![Coverage Status](https://coveralls.io/repos/Visgean/urljects/badge.svg?branch=master&service=github)](https://coveralls.io/github/Visgean/urljects?branch=master)
 
 
-Getting rid of ``urls.py``
---------------------------
+## Getting rid of ``urls.py``
 
 With the use of ``include_view()`` you can avoid ``urls.py`` and include
 your app's views directly in root ``urls.py``.
 
 ```python
+    from urljects import view_include
     # inside your root urls.py
     urlpatterns = [
         # old style
@@ -25,8 +25,7 @@ your app's views directly in root ``urls.py``.
     ]
 ```
 
-Soo how to define URLs directly into views?
-""""""""""""""""""""""""""""""""""""""""""""
+#### Soo how to put urls directly into views?
 
 I am glad you asked! For class based views simply inherit from ``URLView``.
 
@@ -48,8 +47,8 @@ After that you can user ``view_include`` instead of creating ``urls.py`` and
 then old-style ``include`` them afterwards.
 
 
-Keeping ``urls.py``
--------------------
+## I want to keep my urls.py
+
 
 Quite often you need some ``urls.py`` - for example your root urls. Then you can
 use patterns like ``slug`` or ``rest`` as shown above inside your ``urls.py``.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,26 @@ Django URL Objects = URLjects
 [![Coverage Status](https://coveralls.io/repos/Visgean/urljects/badge.svg?branch=master&service=github)](https://coveralls.io/github/Visgean/urljects?branch=master)
 
 
-Routing without urls.py
------------------------
+Getting rid of ``urls.py``
+--------------------------
 
-With the use of ``include_view()`` you can avoid using included ``urls.py``
-and include views directly. 
+With the use of ``include_view()`` you can avoid ``urls.py`` and include
+your app's views directly in root ``urls.py``.
 
-For class based views simply inherit from ``URLView``.
+```python
+    # inside your root urls.py
+    urlpatterns = [
+        # old style
+        url("myapp/", include("myapp.urls")),
+        # new urljects style
+        url("myapp/", view_include("myapp.views"))
+    ]
+```
+
+Soo how to define URLs directly into views?
+""""""""""""""""""""""""""""""""""""""""""""
+
+I am glad you asked! For class based views simply inherit from ``URLView``.
 
 ```python
 class ItemDetail(URLView, DetailView):
@@ -26,30 +39,30 @@ class ItemDetail(URLView, DetailView):
 a lot of people enjoy functional views, for those there is ``url_view`` decorator.
 
 ```python
-@url_view(U / 'detail' / slug)
-def detail(request, slug)
+@url_view(U / 'category' / rest)
+def detail(request, rest)
     ...
 ```
 
+After that you can user ``view_include`` instead of creating ``urls.py`` and
+then old-style ``include`` them afterwards.
 
-URLjects Patterns
------------------
 
-With URLjects you can write this
+Keeping ``urls.py``
+-------------------
+
+Quite often you need some ``urls.py`` - for example your root urls. Then you can
+use patterns like ``slug`` or ``rest`` as shown above inside your ``urls.py``.
+We even provide modified ``url`` function to strip away the boilerplate of
+``.as_view()``,
 
 ```python
 from urljects import U, slug, url
 
 url_patterns = (
     url(U / 'detail' / slug, view=DetailView),
-)
-```
-
-instead of this:
-
-```python 
-url_patterns = (
-    url(r'^detail/(?P<slug>[\w-]+)' , view=DetailView.as_view(), 
+    # instead of
+    url(r'^detail/(?P<slug>[\w-]+)' , view=DetailView.as_view(),
         name='detail'),
 )
 ```

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ Django URL routing system DRYed.
 
 
 requirements = [
-    'django>=1.8',
+    'django>=1.9',
     'six',
 ]
 
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/tests/included_app/routed_views.py
+++ b/tests/included_app/routed_views.py
@@ -1,6 +1,9 @@
+import django
 from django.views.generic.base import View
 
 from urljects import RouteMap, U
+
+DJANGO_GTE_1_10 = django.VERSION[:2] >= (1, 10)
 
 route = RouteMap()
 
@@ -14,3 +17,10 @@ class RoutedView(View):
 @route(U / 'aliased_view', name='aliased_view')
 def routed_view():
     pass
+
+
+def string_view():
+    pass
+
+if not DJANGO_GTE_1_10:
+    route(U / 'string_view', 'tests.included_app.routed_views.string_view')

--- a/tests/included_app/routed_views.py
+++ b/tests/included_app/routed_views.py
@@ -3,7 +3,7 @@ from django.views.generic.base import View
 
 from urljects import RouteMap, U
 
-DJANGO_GTE_1_10 = django.VERSION[:2] >= (1, 10)
+DJANGO_GTE_1_9 = django.VERSION[:2] >= (1, 9)
 
 route = RouteMap()
 
@@ -22,5 +22,5 @@ def routed_view():
 def string_view():
     pass
 
-if not DJANGO_GTE_1_10:
+if not DJANGO_GTE_1_9:
     route(U / 'string_view', 'tests.included_app.routed_views.string_view')

--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -57,6 +57,18 @@ class TestURLjects(unittest.TestCase):
             (U / 'something' / compiled_slug).get_value(),
             (U / 'something' / slug).get_value())
 
+    def test_separated_values(self):
+        """Tests that separator in values does not lead to double-separated url."""
+        self.assertEqual(
+            (U / '/something').get_value(),
+            (U / 'something').get_value())
+        self.assertEqual(
+            (U / 'something' / '/else').get_value(),
+            (U / 'something' / 'else').get_value())
+        self.assertEqual(
+            (U / '/something' / '/else').get_value(),
+            (U / 'something' / 'else').get_value())
+
 
 class TestURL(unittest.TestCase):
     """

--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from urljects import U, slug, url
 from . import views
 
-DJANGO_GTE_1_10 = django.VERSION[:2] >= (1, 10)
+DJANGO_GTE_1_9 = django.VERSION[:2] >= (1, 9)
 
 URLTest = namedtuple('URLTest', ['old_url', 'new_url'])
 test_data = [
@@ -88,7 +88,7 @@ class TestURL(unittest.TestCase):
             name='test_view',
         )
 
-    @unittest.skipIf(DJANGO_GTE_1_10, "Django >= 1.10 has deprecated string views")
+    @unittest.skipIf(DJANGO_GTE_1_9, "Django >= 1.9 has deprecated string views")
     @mock.patch('django.conf.urls.url')
     def test_string_view(self, mocked_url):
         url(U / 'test', view='views.test_view')
@@ -134,14 +134,14 @@ class TestAPP(unittest.TestCase):
         self.assertEqual(reverse(viewname='named:IncludedView'),
                          u'/included/IncludedView')
 
-    @unittest.skipIf(DJANGO_GTE_1_10, "Django >= 1.10 has deprecated string views")
+    @unittest.skipIf(DJANGO_GTE_1_9, "Django >= 1.9 has deprecated string views")
     def test_string_included_views(self):
         self.assertEqual(reverse(viewname='string_import:included_view'),
                          u'/string/included_view')
         self.assertEqual(reverse(viewname='string_import:IncludedView'),
                          u'/string/IncludedView')
 
-    @unittest.skipIf(DJANGO_GTE_1_10, "Django >= 1.10 has deprecated string views")
+    @unittest.skipIf(DJANGO_GTE_1_9, "Django >= 1.9 has deprecated string views")
     def test_wild_card(self):
         self.assertEqual(reverse(viewname='wild_card:included_view'),
                          u'/included_view')
@@ -155,6 +155,6 @@ class TestAPP(unittest.TestCase):
                          u'/routed/routed_view')
         self.assertEqual(reverse(viewname='routed:aliased_view'),
                          u'/routed/aliased_view')
-        if not DJANGO_GTE_1_10:
+        if not DJANGO_GTE_1_9:
             self.assertEqual(reverse(viewname='routed:string_view'),
                              u'/routed/string_view')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py34, py35
 
 [testenv]
 setenv =

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -17,10 +17,10 @@ RE_TYPE = re._pattern_type   # pylint:disable=protected-access
 
 
 class URLPattern(object):
-    """
-    This is the main urljects object, it is able to join strings and
-    regular expressions. The value of this object will always be regular
-    expression usable in django url.
+    """The main urljects object able to join strings and regular expressions.
+
+    The value of this object will always be regular expression usable in django
+    url.
     """
 
     def __init__(self, value=None, separator=SEPARATOR, ends=True):

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -6,6 +6,7 @@ end = r'$'
 slug = r'(?P<slug>[\w-]+)'
 pk = '(?P<pk>\d+)'
 uuid4 = '(?P<uuid4>[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})'  # noqa
+rest = '(?P<rest>[\w\-\_\.\@\:/]*)'  # match anything acceptable in URL
 
 year = r'(?P<year>\d{4})'
 month = r'(?P<month>0?([1-9])|10|11|12)'

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -30,7 +30,7 @@ class URLPattern(object):
         :param separator: used to separate parts of the url, usually /
         :param ends: open urls should be used only for included urls
         """
-        self.parts = [value] if value else []
+        self.parts = [value.strip(separator)] if value else []
         self.separator = separator
         self.ends = ends
 
@@ -49,7 +49,10 @@ class URLPattern(object):
                 separator=self.separator,
                 ends=self.ends)
         else:
-            self.parts.append(part)
+            # stripping separator enables translated urls with hint what
+            # string is actual url and which is a normal word
+            # url(U / _('/my-profile'), private.Home, name="admin-home"),
+            self.parts.append(part.strip(self.separator))
         return self
 
     def get_value(self, ends_override=None):

--- a/urljects/routemap.py
+++ b/urljects/routemap.py
@@ -25,8 +25,8 @@ class RouteMap(object):
 
         :param name: name of the view; resolve_name() will be used otherwise.
         :param priority: priority for sorting; pass e.g. -1 for catch-all route
+        :param kwargs: passed to url()
         """
-
         def router_decorator(view):
             if name is None:
                 resolved_name = resolve_name(view)
@@ -54,8 +54,7 @@ class RouteMap(object):
         sorted_entries = sorted(self.routes, key=operator.itemgetter(0),
                                 reverse=True)
 
-        # pylint:disable=unused-variable
-        arg = [u for p, u in sorted_entries]
+        arg = [u for _, u in sorted_entries]
         return url(location, urls.include(
             arg=arg,
             namespace=namespace,

--- a/urljects/routemap.py
+++ b/urljects/routemap.py
@@ -6,17 +6,14 @@ from .urljects import url, resolve_name
 
 
 class RouteMap(object):
-    """
-        Records mapping of URLs to views
-    """
+    """Records mapping of URLs to views."""
 
     def __init__(self):
         self.routes = []
 
     def __call__(self, url_pattern, view=None, name=None, priority=0,
                  kwargs=None):
-        """
-        Register a URL -> view mapping, or return a registering decorator
+        """Register a URL -> view mapping, or return a registering decorator.
 
         :param url_pattern: regex or URLPattern or anything passable to url()
         :param view: The view. If None, a decorator will be returned

--- a/urljects/urljects.py
+++ b/urljects/urljects.py
@@ -90,7 +90,6 @@ def url(url_pattern, view, kwargs=None, name=None):
     :param view: function/string/class of the view
     :param kwargs: kwargs that are to be passed to view
     :param name: name of the view, if empty it will be guessed
-    :param prefix: useless, use namespaces
     """
     if isinstance(url_pattern, URLPattern):
         if isinstance(view, tuple):  # this is included view

--- a/urljects/urljects.py
+++ b/urljects/urljects.py
@@ -108,8 +108,7 @@ def url(url_pattern, view, kwargs=None, name=None):
         regex=url_pattern,
         view=view,
         kwargs=kwargs,
-        name=name,
-        )
+        name=name)
 
 
 def view_include(view_module, namespace=None, app_name=None):


### PR DESCRIPTION
Hi,
I see we did the same changes in parallel. When resolving conflicts, I kept my solution, which is less destructive - just forbid the string views for django >= 1.10.

In addition I contribute with subjectively easier-to-start readme.

The last feature is stripping the separator from URL bits. In case the separators are necessary in URL bits we would end up with double-separated url strings.

Sorry for three new things in this PR. It was unfortunate that we did the same work almost at the same time.

Cheers,
Kato