### PR TITLE
Add rename feature!

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from django.views.generic import DetailView
 
 class ItemDetail(URLView, DetailView):
     name = 'detail'
-    url = U / 'detail' / slug
+    url_name = U / 'detail' / slug
 ```
 
 A lot of people enjoy functional views, for those there is ``url_view`` decorator.
@@ -57,7 +57,7 @@ def detail(request, rest)
     ...
 ```
 
-After that you can user ``view_include`` instead of creating ``urls.py`` and
+After that you can use ``view_include`` instead of creating ``urls.py`` and
 then old-style ``include`` them afterwards.
 
 
@@ -72,14 +72,29 @@ We even provide modified ``url`` function to strip away the boilerplate of
 from urljects import U, slug, url
 
 url_patterns = (
-    url(U / 'detail' / slug, view=DetailView),
+    url(U / 'detail' / slug, view=DetailView),  # has to define DetailView.url_name
     # instead of
     url(r'^detail/(?P<slug>[\w-]+)' , view=DetailView.as_view(),
         name='detail'),
 )
 ```
+In this example, if you don't provide the name for the url then the view has to
+define ``DetailView.url_name`` or be a function (name is the name of the function).
 
-The name of the view has been taken from ``DetailView.url_name``.
-There are also some common regular patterns like slugs and UUIDs so that you
-can focus on more important stuff than on debugging regular expressions.
+## I cannot use your pre-defined names like 'slug' or 'rest'
 
+When you have hard-coded parameters in views you can still use urljects! Modulo
+operator does the trick.
+
+```python
+
+# url definition
+url(U / 'account' / slug, my_view)
+url(U / 'account' / slug % 'username', provided_view)
+
+# view definition before renaming
+def view_user(request, slug):
+
+# view definition after renaming
+def provided_view(request, username)
+```

--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -9,7 +9,7 @@ import unittest
 
 from django.core.urlresolvers import reverse
 from collections import namedtuple
-from urljects import U, slug, url
+from urljects import U, slug, url, pk, end
 from . import views
 
 DJANGO_GTE_1_9 = django.VERSION[:2] >= (1, 9)
@@ -68,6 +68,18 @@ class TestURLjects(unittest.TestCase):
         self.assertEqual(
             (U / '/something' / '/else').get_value(),
             (U / 'something' / 'else').get_value())
+
+    def test_renamed(self):
+        """Tests that renaming of patterns work fine."""
+        self.assertEqual(
+            (U / r'(?P<plug>[\w-]+)').get_value(),
+            (U / r'(?P<slug>[\w-]+)' % 'plug').get_value())
+        self.assertEqual(
+            (U / r'(?P<plug>[\w-]+)' / pk).get_value(),
+            (U / r'(?P<slug>[\w-]+)' % 'plug' / pk).get_value())
+        self.assertEqual(
+            (U / r'(?P<plug>[\w-]+)' / end).get_value(),
+            (U / r'(?P<slug>[\w-]+)' % 'plug' / end).get_value())
 
 
 class TestURL(unittest.TestCase):

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -4,9 +4,9 @@ beginning = r'^'
 end = r'$'
 
 slug = r'(?P<slug>[\w-]+)'
-pk = '(?P<pk>\d+)'
-uuid4 = '(?P<uuid4>[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})'  # noqa
-rest = '(?P<rest>[\w\-\_\.\@\:/]*)'  # match anything acceptable in URL
+pk = r'(?P<pk>\d+)'
+uuid4 = r'(?P<uuid4>[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12})'  # noqa
+rest = r'(?P<rest>[\w\-\_\.\@\:/]*)'  # match anything acceptable in URL
 
 year = r'(?P<year>\d{4})'
 month = r'(?P<month>0?([1-9])|10|11|12)'

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -24,6 +24,7 @@ class URLPattern(object):
     The value of this object will always be regular expression usable in django
     url.
     """
+    name_re = re.compile(r'P<([\w_-]+)>')
 
     def __init__(self, value=None, separator=SEPARATOR, ends=True):
         """
@@ -40,8 +41,8 @@ class URLPattern(object):
             self.add_part(value)
 
     def add_part(self, part):
-        """
-        Function for adding partial pattern to the value
+        """Append new pattern to the URL.
+
         :param part: string or compiled pattern
         """
         if isinstance(part, RE_TYPE):
@@ -54,14 +55,12 @@ class URLPattern(object):
         return self
 
     def get_value(self, ends_override=None):
-        """
-        This function finishes the url pattern creation by adding starting
-        character ^ end possibly by adding end character at the end
+        """Finish the url pattern by adding starting and optionally ending.
 
         :param ends_override: overrides ``self.ends``
         :return: raw string
         """
-        value = self.separator.join(self.parts)
+        value = self.separator.join(filter(None, self.parts))
         ends = ends_override if ends_override is not None else self.ends
 
         if not value:  # use case: wild card imports
@@ -82,16 +81,17 @@ class URLPattern(object):
         return value
 
     def __div__(self, other):
-        """
-        PY2 division
-        """
+        """PY2 division."""
         return self.add_part(other)
 
     def __truediv__(self, other):
-        """
-        PY3 division
-        """
+        """PY3 division."""
         return self.add_part(other)
+
+    def __mod__(self, other):
+        """Use % operator ro rename last pattern."""
+        last_pattern = self.parts.pop()
+        return self.add_part(self.name_re.sub('P<' + other + '>', last_pattern))
 
     def __repr__(self):
         return self.get_value() or ''

--- a/urljects/urljects.py
+++ b/urljects/urljects.py
@@ -5,7 +5,7 @@ import importlib
 
 from collections import defaultdict
 from django.conf import urls
-from .patterns import URLPattern
+from .patterns import URLPattern, URLFactory
 
 
 class URLView(object):
@@ -91,7 +91,7 @@ def url(url_pattern, view, kwargs=None, name=None):
     :param kwargs: kwargs that are to be passed to view
     :param name: name of the view, if empty it will be guessed
     """
-    if isinstance(url_pattern, URLPattern):
+    if isinstance(url_pattern, (URLPattern, URLFactory)):
         if isinstance(view, tuple):  # this is included view
             url_pattern = url_pattern.get_value(ends_override=False)
         else:


### PR DESCRIPTION
Please merge after #12 

Add capability to rename hard coded names inside patters.
```python
url(U / 'user' / slug, my_view) # view has to be def my_view(request, slug)
# but in case of libraries we often need a different argument name than 'slug'
url(U / 'user' / slug % 'username', library_view) # view is def library_view(request, username)
```

I think that modulo operator reminds of formatting operator thus can be viewed as formatting the name. Hope you like this solution.

Cheers
Tom