### PR TITLE
Reimplement URLPattern as str subclass

### DIFF
--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -38,10 +38,10 @@ class TestURLjects(unittest.TestCase):
             self.assertEqual(url_test.old_url, url_test.new_url)
 
     def test_str_method(self):
-        """Test that __repr__ returns expected value."""
+        """Test that stringification returns expected value."""
         for url_test in test_data:
             self.assertEqual(
-                url_test.new_url.__repr__(),
+                str(url_test.new_url),
                 url_test.new_url)
 
     def test_compile(self):
@@ -61,13 +61,13 @@ class TestURLjects(unittest.TestCase):
         """Tests that separator in values does not lead to double-separated url."""
         self.assertEqual(
             (U / '/something'),
-            (U / 'something'))
+            '^/something$')
         self.assertEqual(
             (U / 'something' / '/else'),
             (U / 'something' / 'else'))
         self.assertEqual(
             (U / '/something' / '/else'),
-            (U / 'something' / 'else'))
+            '^/something/else$')
 
 
 class TestURL(unittest.TestCase):

--- a/tests/test_urljects.py
+++ b/tests/test_urljects.py
@@ -35,39 +35,39 @@ class TestURLjects(unittest.TestCase):
     def test_regulars(self):
         """Test that old_url is same as new_url."""
         for url_test in test_data:
-            self.assertEqual(url_test.old_url, url_test.new_url.get_value())
+            self.assertEqual(url_test.old_url, url_test.new_url)
 
     def test_str_method(self):
         """Test that __repr__ returns expected value."""
         for url_test in test_data:
             self.assertEqual(
                 url_test.new_url.__repr__(),
-                url_test.new_url.get_value())
+                url_test.new_url)
 
     def test_compile(self):
         """Tests that U object can actually compile to regex."""
         patterns_to_compile = (g.new_url for g in test_data)
         for pattern in patterns_to_compile:
-            re.compile(pattern.get_value())
+            re.compile(pattern)
 
     def test_compiled_pattern(self):
         """Tests that U object can work with compiled patterns."""
         compiled_slug = re.compile(slug)
         self.assertEqual(
-            (U / 'something' / compiled_slug).get_value(),
-            (U / 'something' / slug).get_value())
+            (U / 'something' / compiled_slug),
+            (U / 'something' / slug))
 
     def test_separated_values(self):
         """Tests that separator in values does not lead to double-separated url."""
         self.assertEqual(
-            (U / '/something').get_value(),
-            (U / 'something').get_value())
+            (U / '/something'),
+            (U / 'something'))
         self.assertEqual(
-            (U / 'something' / '/else').get_value(),
-            (U / 'something' / 'else').get_value())
+            (U / 'something' / '/else'),
+            (U / 'something' / 'else'))
         self.assertEqual(
-            (U / '/something' / '/else').get_value(),
-            (U / 'something' / 'else').get_value())
+            (U / '/something' / '/else'),
+            (U / 'something' / 'else'))
 
 
 class TestURL(unittest.TestCase):

--- a/urljects/patterns.py
+++ b/urljects/patterns.py
@@ -17,22 +17,54 @@ SEPARATOR = '/'  # separator for parts of the url
 RE_TYPE = re._pattern_type   # pylint:disable=protected-access
 
 
-class URLPattern(object):
+def render(parts, separator=SEPARATOR, ends=True):
+    """
+    This function finishes the url pattern creation by adding starting
+    character ^ end possibly by adding end character at the end
+
+    :param parts: URL parts
+    :param separator: used to separate parts of the url, usually /
+    :param ends: open urls should be used only for included urls
+    :return: raw string
+    """
+    value = separator.join(parts)
+
+    if not value:  # use case: wild card imports
+        if ends:
+            return r'^$'
+        return r'^'
+
+    if value[0] != beginning:
+        value = beginning + value
+
+    if ends and value[-1] != end:
+        value += end
+
+    # included views usually ends with separator
+    if not ends and value[-1] != separator:
+        value += separator
+
+    return value
+
+
+class URLPattern(str):
     """The main urljects object able to join strings and regular expressions.
 
     The value of this object will always be regular expression usable in django
     url.
     """
-
-    def __init__(self, value=None, separator=SEPARATOR, ends=True):
+    def __new__(cls, value='', separator=SEPARATOR, ends=True):
         """
         :param value: Initial value of the URL
         :param separator: used to separate parts of the url, usually /
         :param ends: open urls should be used only for included urls
         """
-        self.parts = [value.strip(separator)] if value else []
+        parts = (value.strip(separator),) if value else ()
+        self = str.__new__(cls, render(parts, separator, ends))
+        self.parts = parts
         self.separator = separator
         self.ends = ends
+        return self
 
     def add_part(self, part):
         """
@@ -52,36 +84,16 @@ class URLPattern(object):
             # stripping separator enables translated urls with hint what
             # string is actual url and which is a normal word
             # url(U / _('/my-profile'), private.Home, name="admin-home"),
-            self.parts.append(part.strip(self.separator))
+            parts = self.parts + (part.strip(self.separator),)
+            return URLPattern(
+                value=self.separator.join(parts),
+                separator=self.separator,
+                ends=self.ends)
         return self
 
     def get_value(self, ends_override=None):
-        """
-        This function finishes the url pattern creation by adding starting
-        character ^ end possibly by adding end character at the end
-
-        :param ends_override: overrides ``self.ends``
-        :return: raw string
-        """
-        value = self.separator.join(self.parts)
-        ends = ends_override if ends_override is not None else self.ends
-
-        if not value:  # use case: wild card imports
-            if ends:
-                return r'^$'
-            return r'^'
-
-        if value[0] != beginning:
-            value = beginning + value
-
-        if ends and value[-1] != end:
-            value += end
-
-        # included views usually ends with separator
-        if not ends and value[-1] != self.separator:
-            value += self.separator
-
-        return value
+        ends = self.ends if ends_override is None else ends_override
+        return render(self.parts, self.separator, ends)
 
     def __div__(self, other):
         """
@@ -96,7 +108,7 @@ class URLPattern(object):
         return self.add_part(other)
 
     def __repr__(self):
-        return self.get_value() or ''
+        return self or ''
 
 
 U = URLPattern()

--- a/urljects/urljects.py
+++ b/urljects/urljects.py
@@ -95,7 +95,7 @@ def url(url_pattern, view, kwargs=None, name=None):
         if isinstance(view, tuple):  # this is included view
             url_pattern = url_pattern.get_value(ends_override=False)
         else:
-            url_pattern = url_pattern.get_value()
+            url_pattern = url_pattern
 
     if name is None:
         name = resolve_name(view)

--- a/urljects/urljects.py
+++ b/urljects/urljects.py
@@ -91,11 +91,9 @@ def url(url_pattern, view, kwargs=None, name=None):
     :param kwargs: kwargs that are to be passed to view
     :param name: name of the view, if empty it will be guessed
     """
-    if isinstance(url_pattern, URLPattern):
-        if isinstance(view, tuple):  # this is included view
-            url_pattern = url_pattern.get_value(ends_override=False)
-        else:
-            url_pattern = url_pattern
+    # Special handling for included view
+    if isinstance(url_pattern, URLPattern) and isinstance(view, tuple):
+        url_pattern = url_pattern.for_include()
 
     if name is None:
         name = resolve_name(view)


### PR DESCRIPTION
This has some advantages:
- it's now usable outside urljects helpers such as Django `url()` or really anywhere
- code is cleaner
- fixes mutability bug

On last one: now you modify parts, which can lead to unexpected behavior:
```python
base_url = U / 'base'
u1 = base_url / '1'
u2 = base_url / '2'  # now it's /base/1/2
```